### PR TITLE
feat: #5. Add first commit date to initial repository data

### DIFF
--- a/projects/initial-data/dataRecorder.js
+++ b/projects/initial-data/dataRecorder.js
@@ -10,7 +10,7 @@ export class DataRecorder {
     if (!fs.existsSync(this.fileName)) {
       fs.writeFileSync(
         this.fileName,
-        'repo,repo_topics,creation,archive_url_creation,topic_present_creation,release,archive_url_release,topic_present_release\n',
+        'repo,repo_topics,first_commit_date,creation,archive_url_creation,topic_present_creation,release,archive_url_release,topic_present_release\n',
         'utf8',
       );
     }

--- a/projects/initial-data/main.js
+++ b/projects/initial-data/main.js
@@ -20,16 +20,16 @@ async function fetchFistCommitDate(octokit, owner, repo) {
   console.log(`Fetching the first commit date for repository: ${owner}/${repo}`);
   
   const response = await octokit.request(`GET /repos/${owner}/${repo}/commits`, {
-      owner,
-      repo,
-      per_page: 1,
+    owner,
+    repo,
+    per_page: 1,
   });
   const lastPageUrl = response.headers.link?.match(/<([^>]+)>;\s*rel="last"/,)?.[1];
 
   const firstCommitPageResponse = await octokit.request(`GET ${lastPageUrl}`, {
-      owner,
-      repo,
-      per_page: 1,
+    owner,
+    repo,
+    per_page: 1,
   });
   const firstCommitDate=(firstCommitPageResponse.data[0].commit.author.date);
   const date = new Date(firstCommitDate);

--- a/projects/initial-data/main.js
+++ b/projects/initial-data/main.js
@@ -32,7 +32,9 @@ async function fetchFistCommitDate(octokit, owner, repo) {
       per_page: 1,
   });
   const firstCommitDate=(firstCommitPageResponse.data[0].commit.author.date);
-  return (firstCommitDate);
+  const date = new Date(firstCommitDate);
+  const datestamp = date.getTime();
+  return (datestamp);
 }
 
 async function fetchRepoTopics(octokit, owner, repo) {


### PR DESCRIPTION
Closes #5 

Resulting data before:

|repo|repo_topics|creation|archive_url_creation|topic_present_creation|release|archive_url_release|topic_present_release|
| --- | ---| ---| ---| ---| ---| ---| ---| 
|tiangolo/fastapi|"python,json,swagger-ui,redoc,starlette,openapi,api,openapi3,framework,async,asyncio,uvicorn,python3,python-types,pydantic,json-schema,fastapi,swagger,rest,web"|1544257307000|http://web.archive.org/web/20190204230405/https://github.com/tiangolo/fastapi|true|1544896765000|http://web.archive.org/web/20190204230405/https://github.com/tiangolo/fastapi|true|

Resulting data after:

|repo|repo_topics|first_commit_date|creation|archive_url_creation|topic_present_creation|release|archive_url_release|topic_present_release|
| --- | ---| ---| ---| ---| ---| ---| ---| ---|
|tiangolo/fastapi|"python,json,swagger-ui,redoc,starlette,openapi,api,openapi3,framework,async,asyncio,uvicorn,python3,python-types,pydantic,json-schema,fastapi,swagger,rest,web"|1543993010000|1544257307000|http://web.archive.org/web/20190204230405/https://github.com/tiangolo/fastapi|true|1544896765000|http://web.archive.org/web/20190204230405/https://github.com/tiangolo/fastapi|true|