### PR TITLE
Self reporting tooling schema and processes definition

### DIFF
--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -164,9 +164,10 @@
       "description": "Documents if the tool is the primary validator provider or depends on another tool",
       "type": "array",
       "items": {
-        "description": "The names of the tooling that this tooling depends upon",
-        "$comment": "In the case where it's known that there are implementations with the same name in different programming languages, please use the repository or source URL.",
-        "type": "string"
+        "description": "The list of tooling that this tooling depends upon",
+        "$comment": "This should be the source URL. The source URL should already be known to the ecosystem repository in some way.",
+        "type": "string",
+        "format": "uri"
       }
     },
     "creators": {

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -221,6 +221,32 @@
       },
       "additionalProperties": false
     },
+    "supportedDialectsExtended": {
+      "description": "Additional Dialects that are supported beyond the ones defined by the JSON Schema project, such as the OpenAPI Dialect.",
+      "type": "array",
+      "items": {
+        "description": "Individual JSON Schema Dialect items",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "homepage": {
+            "type": "string",
+            "format": "uri"
+          },
+          "source": {
+            "type": "string",
+            "format": "uri"
+          }
+        },
+        "required": [
+          "name",
+          "source"
+        ],
+        "additionalProperties": false
+      }
+    },
     "bowtie": {
       "description": "Information related to compliance testing by Bowtie - https://bowtie.report - Presence of this property implies the tool is being tested in Bowtie",
       "type": "object",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -186,12 +186,12 @@
     "source": {
       "description": "The URL of the project's repository",
       "type": "string",
-      "format": "URL"
+      "format": "uri"
     },
     "homepage": {
       "description": "The URL of the project's homepage",
       "type": "string",
-      "format": "URL"
+      "format": "uri"
     },
     "documentation": {
       "$comment": "This is reserved for future use",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -273,7 +273,8 @@
           "type": "boolean",
           "default": false
         }
-      }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -146,6 +146,7 @@
       "type": "array",
       "items": {
         "description": "The names of the tooling that this tooling depends upon",
+        "$comment": "In the case where it's known that there are implementations with the same name in different programming languages, please use the repository or source URL.",
         "type": "string"
       }
     },

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -179,7 +179,7 @@
       "description": "The status of the project's repository, defined at https://www.repostatus.org",
       "type": "string",
       "enum": [
-        "concpet",
+        "concept",
         "WIP",
         "suspended",
         "abandoned",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -62,7 +62,7 @@
       "$comment": "If this is omitted and description is already defined on GitHub or GitLab for the repository, we will use that information.",
       "type": "string"
     },
-    "toolingType": {
+    "toolingTypes": {
       "description": "The categories of tooling for the project",
       "type": "array",
       "uniqueItems": true,
@@ -140,7 +140,7 @@
         ]
       }
     },
-    "environment": {
+    "environments": {
       "description": "The platforms or environments in which the tool or library is designed to operate. This field is optional and should be included when the tool or library is specific to a certain platform or environment.",
       "type": "array",
       "items": {

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -66,12 +66,86 @@
           "util-draft-migration",
           "util-format-conversion",
           "util-testing",
-          "editors",
+          "editor",
+          "editor-plugins",
           "schema-to-documentation",
           "schema-repository",
           "linter",
           "linter-plugins"
         ]
+      }
+    },
+    "languages": {
+      "description": "The languages the tool supports or can be used in or with",
+      "type": "array",
+      "items": {
+        "description": "Individual language name, from the list unless not included.",
+        "type": "string",
+        "anyOf": [
+          {
+            "enum": [
+              [
+                "Common Lisp",
+                "Rust",
+                "Elm",
+                ".NET",
+                "PHP",
+                "Clojure",
+                "Python",
+                "XSD",
+                "Scala",
+                "Orderly",
+                "Kotlin",
+                "Elixir",
+                "RAML",
+                "Erlang",
+                "Java",
+                "Lua/LuaJIT",
+                "OpenAPI",
+                "Perl",
+                "TypeScript",
+                "Ruby",
+                "Objective-C",
+                "Swift",
+                "C#",
+                "Go",
+                "C++",
+                "JavaScript"
+              ]
+            ]
+          },
+          {
+            "description": "A string value not yet included in the list of languages"
+          }
+        ]
+      }
+    },
+    "environment": {
+      "description": "The platforms or environments in which the tool or library is designed to operate. This field is optional and should be included when the tool or library is specific to a certain platform or environment.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "anyOf": [
+          {
+            "enum": [
+              "Web (Online)",
+              "GitHub Actions",
+              "Command Line",
+              "COM/ActiveX"
+            ]
+          },
+          {
+            "description": "A string value not yet included in the list of envrionments"
+          }
+        ]
+      }
+    },
+    "dependsOnValidators": {
+      "description": "Documents if the tool is the primary validator provider or depends on another tool",
+      "type": "array",
+      "items": {
+        "description": "The names of the tooling that this tooling depends upon",
+        "type": "string"
       }
     },
     "creators": {

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -32,32 +32,37 @@
       "type": "string"
     },
     "toolingType": {
-      "description": "The category of tooling of the project",
-      "type": "string",
-      "enum": [
-        "validator",
-        "hyper-schema",
-        "benchmarks",
-        "documentation",
-        "LDO-utility",
-        "code-to-schema",
-        "data-to-schema",
-        "model-to-schema",
-        "schema-to-types",
-        "schema-to-code",
-        "schema-to-web-UI",
-        "schema-to-data",
-        "util-general-processing",
-        "util-schema-to-schema",
-        "util-draft-migration",
-        "util-format-conversion",
-        "util-testing",
-        "editors",
-        "schema-to-documentation",
-        "schema-repository",
-        "linter",
-        "linter-plugins"
-      ]
+      "description": "The categories of tooling for the project",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "description": "One of the categories of tooling of the project",
+        "type": "string",
+        "enum": [
+          "validator",
+          "hyper-schema",
+          "benchmarks",
+          "documentation",
+          "LDO-utility",
+          "code-to-schema",
+          "data-to-schema",
+          "model-to-schema",
+          "schema-to-types",
+          "schema-to-code",
+          "schema-to-web-UI",
+          "schema-to-data",
+          "util-general-processing",
+          "util-schema-to-schema",
+          "util-draft-migration",
+          "util-format-conversion",
+          "util-testing",
+          "editors",
+          "schema-to-documentation",
+          "schema-repository",
+          "linter",
+          "linter-plugins"
+        ]
+      }
     },
     "creators": {
       "description": "The creators or authors of the project",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -262,7 +262,7 @@
       }
     },
     "landscape": {
-      "description": "Additional informatin that should be used when generating the JSON Schema landscape diagram - https://github.com/json-schema-org/landscape",
+      "description": "Additional information that should be used when generating the JSON Schema landscape diagram - https://github.com/json-schema-org/landscape",
       "type": "object",
       "properties": {
         "logo": {

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -7,9 +7,13 @@
   "$defs": {
     "persons": {
       "type": "array",
+      "uniqueItems": "true",
       "items": {
-        "$comment": "TODO: Fill in this schema.",
         "type": "object",
+        "required": [
+          "name",
+          "github"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -17,7 +21,8 @@
           "github": {
             "type": "string"
           }
-        }
+        },
+        "additionalProperties": false
       }
     }
   },

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -11,18 +11,38 @@
       "items": {
         "type": "object",
         "required": [
-          "name",
-          "github"
+          "username",
+          "platform"
         ],
         "properties": {
           "name": {
+            "description": "The persons name, should they wish to provide it",
             "type": "string"
           },
-          "github": {
+          "email": {
+            "description": ""
+          },
+          "username": {
+            "description": "The persons username on the platform where the user exists",
             "type": "string"
-          }
-        },
-        "additionalProperties": false
+          },
+          "platform": {
+            "type": "string",
+            "anyOf": [
+              {
+                "enum": [
+                  "github",
+                  "gitlab",
+                  "bitbucket"
+                ]
+              },
+              {
+                "description": "A string value not yet included in the list of platforms"
+              }
+            ]
+          },
+          "additionalProperties": false
+        }
       }
     }
   },
@@ -163,33 +183,9 @@
       "$comment": "Schemastore package.json schema uses enum to assist in auto complete. Could be worth doing the same.",
       "type": "string"
     },
-    "projectType": {
-      "description": "The type of project, classified by Nadia Eghbal in Working in Public - https://project-types.github.io",
-      "type": "string",
-      "enum": [
-        "toy",
-        "club",
-        "stadium",
-        "federation"
-      ]
-    },
     "repositoryURL": {
       "type": "string",
       "description": "The URL of the project's repository"
-    },
-    "repositoryStatus": {
-      "description": "The status of the project's repository, defined at https://www.repostatus.org",
-      "type": "string",
-      "enum": [
-        "concept",
-        "WIP",
-        "suspended",
-        "abandoned",
-        "active",
-        "inactive",
-        "unsupported",
-        "moved"
-      ]
     },
     "homepageURL": {
       "description": "The URL of the project's homepage",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -39,6 +39,7 @@
     },
     "description": {
       "description": "A brief description of the project",
+      "$comment": "If this is omitted and description is already defined on GitHub or GitLab for the repository, we will use that information.",
       "type": "string"
     },
     "toolingType": {
@@ -284,7 +285,6 @@
   },
   "required": [
     "name",
-    "description",
     "repositoryURL",
     "toolingType",
     "lastUpdated"

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -275,18 +275,12 @@
           "default": false
         }
       }
-    },
-    "lastUpdated": {
-      "description": "A date in the format of YYYY-MM-DD which repersents when the document was last updated.",
-      "type": "string",
-      "regex": "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$"
     }
   },
   "required": [
     "name",
     "source",
-    "toolingType",
-    "lastUpdated"
+    "toolingType"
   ],
   "additionalProperties": false
 }

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -194,7 +194,10 @@
   },
   "required": [
     "name",
-    "repositoryURL"
+    "description",
+    "repositoryURL",
+    "toolingType",
+    "lastUpdated"
   ],
   "additionalProperties": false
 }

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -183,13 +183,15 @@
       "$comment": "Schemastore package.json schema uses enum to assist in auto complete. Could be worth doing the same.",
       "type": "string"
     },
-    "repositoryURL": {
+    "source": {
+      "description": "The URL of the project's repository",
       "type": "string",
-      "description": "The URL of the project's repository"
+      "format": "URL"
     },
-    "homepageURL": {
+    "homepage": {
       "description": "The URL of the project's homepage",
-      "type": "string"
+      "type": "string",
+      "format": "URL"
     },
     "documentation": {
       "$comment": "This is reserved for future use",
@@ -282,7 +284,7 @@
   },
   "required": [
     "name",
-    "repositoryURL",
+    "source",
     "toolingType",
     "lastUpdated"
   ],

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -164,7 +164,7 @@
       "description": "Documents if the tool is the primary validator provider or depends on another tool",
       "type": "array",
       "items": {
-        "description": "The list of tooling that this tooling depends upon",
+        "description": "One of the tools that this tool depends upon",
         "$comment": "This should be the source URL. The source URL should already be known to the ecosystem repository in some way.",
         "type": "string",
         "format": "uri"
@@ -307,7 +307,7 @@
   "required": [
     "name",
     "source",
-    "toolingType"
+    "toolingTypes"
   ],
   "additionalProperties": false
 }

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -155,7 +155,7 @@
             ]
           },
           {
-            "description": "A string value not yet included in the list of envrionments"
+            "description": "A string value not yet included in the list of environments"
           }
         ]
       }

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -186,7 +186,7 @@
         }
       }
     },
-    "last-updated": {
+    "lastUpdated": {
       "description": "A date in the format of YYYY-MM-DD which repersents when the document was last updated.",
       "type": "string",
       "regex": "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$"

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -96,7 +96,7 @@
       }
     },
     "languages": {
-      "description": "The languages the tool supports or can be used in or with",
+      "description": "The language or languages a tool is built in. In the case of a validator, this will likely be the language it is written in. In the case of a conversion or transformation tool, these are the languages that are supported in some capacity.",
       "type": "array",
       "items": {
         "description": "Individual language name, from the list unless not included.",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -218,7 +218,8 @@
             ]
           }
         }
-      }
+      },
+      "additionalProperties": false
     },
     "bowtie": {
       "description": "Information related to compliance testing by Bowtie - https://bowtie.report - Presence of this property implies the tool is being tested in Bowtie",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -28,6 +28,11 @@
   },
   "type": "object",
   "properties": {
+    "$schema": {
+      "description": "Identifies the exact version of the schema and self reporting data structure to which the file intends to conform",
+      "type": "string",
+      "pattern": "https://schemas.json-schema.org/ecosystem/identification-v-\\d\\.\\d\\.\\d"
+    },
     "name": {
       "description": "The name of the project",
       "type": "string"

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -217,35 +217,35 @@
               "2020-12"
             ]
           }
+        },
+        "additional": {
+          "description": "Additional Dialects that are supported beyond the ones defined by the JSON Schema project, such as the OpenAPI Dialect.",
+          "type": "array",
+          "items": {
+            "description": "Individual JSON Schema Dialect items",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "homepage": {
+                "type": "string",
+                "format": "uri"
+              },
+              "source": {
+                "type": "string",
+                "format": "uri"
+              }
+            },
+            "required": [
+              "name",
+              "source"
+            ],
+            "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false
-    },
-    "supportedDialectsExtended": {
-      "description": "Additional Dialects that are supported beyond the ones defined by the JSON Schema project, such as the OpenAPI Dialect.",
-      "type": "array",
-      "items": {
-        "description": "Individual JSON Schema Dialect items",
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "homepage": {
-            "type": "string",
-            "format": "uri"
-          },
-          "source": {
-            "type": "string",
-            "format": "uri"
-          }
-        },
-        "required": [
-          "name",
-          "source"
-        ],
-        "additionalProperties": false
-      }
     },
     "bowtie": {
       "description": "Information related to compliance testing by Bowtie - https://bowtie.report - Presence of this property implies the tool is being tested in Bowtie",

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -1,0 +1,195 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.json-schema.org/ecosystem/identification-v-0.0.1",
+  "title": "Tooling Project Self Identification Document",
+  "$comment": "Decided not to use JSON-LD and Schema.org concepts, as this complicates things without a clear benefit for our use case.",
+  "description": "This is a schema which represents a self reporting document published by a JSON Schema tooling creator, maintainer, or vendor.",
+  "$defs": {
+    "persons": {
+      "type": "array",
+      "items": {
+        "$comment": "TODO: Fill in this schema.",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "github": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "name": {
+      "description": "The name of the project",
+      "type": "string"
+    },
+    "description": {
+      "description": "A brief description of the project",
+      "type": "string"
+    },
+    "toolingType": {
+      "description": "The category of tooling of the project",
+      "type": "string",
+      "enum": [
+        "validator",
+        "hyper-schema",
+        "benchmarks",
+        "documentation",
+        "LDO-utility",
+        "code-to-schema",
+        "data-to-schema",
+        "model-to-schema",
+        "schema-to-types",
+        "schema-to-code",
+        "schema-to-web-UI",
+        "schema-to-data",
+        "util-general-processing",
+        "util-schema-to-schema",
+        "util-draft-migration",
+        "util-format-conversion",
+        "util-testing",
+        "editors",
+        "schema-to-documentation",
+        "schema-repository",
+        "linter",
+        "linter-plugins"
+      ]
+    },
+    "creators": {
+      "description": "The creators or authors of the project",
+      "$ref": "#/$defs/persons"
+    },
+    "maintainers": {
+      "description": "The maintainers of the project",
+      "$ref": "#/$defs/persons"
+    },
+    "license": {
+      "description": "The license under which the project is distributed. SPDX expressions or a URL.",
+      "$comment": "Schemastore package.json schema uses enum to assist in auto complete. Could be worth doing the same.",
+      "type": "string"
+    },
+    "projectType": {
+      "description": "The type of project, classified by Nadia Eghbal in Working in Public - https://project-types.github.io",
+      "type": "string",
+      "enum": [
+        "toy",
+        "club",
+        "stadium",
+        "federation"
+      ]
+    },
+    "repositoryURL": {
+      "type": "string",
+      "description": "The URL of the project's repository"
+    },
+    "repositoryStatus": {
+      "description": "The status of the project's repository, defined at https://www.repostatus.org",
+      "type": "string",
+      "enum": [
+        "concpet",
+        "WIP",
+        "suspended",
+        "abandoned",
+        "active",
+        "inactive",
+        "unsupported",
+        "moved"
+      ]
+    },
+    "homepageURL": {
+      "description": "The URL of the project's homepage",
+      "type": "string"
+    },
+    "documentation": {
+      "$comment": "This is reserved for future use",
+      "type": "object"
+    },
+    "supportedDialects": {
+      "description": "The declared supported dialects of JSON Schema. This includes draft version identifiers.",
+      "type": "object",
+      "properties": {
+        "draft": {
+          "description": "An array of dialects of JSON Schema.",
+          "type": "array",
+          "items": {
+            "enum": [
+              1,
+              2,
+              3,
+              4,
+              5,
+              6,
+              7,
+              "2019-09",
+              "2020-12"
+            ]
+          }
+        }
+      }
+    },
+    "bowtie": {
+      "description": "Information related to compliance testing by Bowtie - https://bowtie.report - Presence of this property implies the tool is being tested in Bowtie",
+      "type": "object",
+      "properties": {
+        "identifier": {
+          "description": "The identifier used for the tool in Bowtie, including the language.",
+          "examples": [
+            "dotnet-jsonschema-net",
+            "js-ajv"
+          ]
+        }
+      },
+      "required": [
+        "identifier"
+      ],
+      "additionalProperties": false
+    },
+    "toolingListingNotes": {
+      "description": "Notes about the tooling which will appear in the tooling listing on the website.",
+      "type": "string"
+    },
+    "compliance": {
+      "description": "Details on what must be done to make the implementation the most compliant that it can be. This is displayed on the website with the tooling details",
+      "type": "object",
+      "properties": {
+        "config": {
+          "type": "object",
+          "properties": {
+            "docs": {
+              "description": "A URL which links to the documentation which explains how to follow the given instructions.",
+              "type": "string"
+            },
+            "instructions": {
+              "description": "Instructions on how to make the implementation the most compliant.",
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "landscape": {
+      "description": "Additional informatin that should be used when generating the JSON Schema landscape diagram - https://github.com/json-schema-org/landscape",
+      "type": "object",
+      "properties": {
+        "logo": {
+          "description": "The filename of the logo to use for the JSON Schema landscape diagram - Must be included in the landscape repo under the logos directory, and in SVG format.",
+          "type": "string"
+        }
+      }
+    },
+    "last-updated": {
+      "description": "A date in the format of YYYY-MM-DD which repersents when the document was last updated.",
+      "type": "string",
+      "regex": "^\\d{4}\\-(0[1-9]|1[012])\\-(0[1-9]|[12][0-9]|3[01])$"
+    }
+  },
+  "required": [
+    "name",
+    "repositoryURL"
+  ],
+  "additionalProperties": false
+}

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -193,6 +193,11 @@
         "logo": {
           "description": "The filename of the logo to use for the JSON Schema landscape diagram - Must be included in the landscape repo under the logos directory, and in SVG format.",
           "type": "string"
+        },
+        "optOut": {
+          "description": "Set this value to a boolean `true` value if you do not wish to be included in the JSON Schema Landscape. If you do, we would like to hear why.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/projects/tooling-self-identification/identification.schema.json
+++ b/projects/tooling-self-identification/identification.schema.json
@@ -89,7 +89,6 @@
           "util-testing",
           "editor",
           "editor-plugins",
-          "schema-to-documentation",
           "schema-repository",
           "linter",
           "linter-plugins"

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -2,7 +2,7 @@
 
 JSON Schema has a vast ecosystem. We have documented a fraction of the existing tools out there for JSON Schema.
 
-This project aims to enable tooling authors and maintainers to detail their tools existance and additional informaiton to be listed on the JSON Schema website and Landscape diagram.
+This project aims to enable tooling authors and maintainers to detail their tools existence and additional information to be listed on the JSON Schema website and Landscape diagram.
 
 The approach is to define a data structure for a file which is located in their own repo, which will then be located and extracted into a single file within this repository. Other repositories such as the website and landscape repositories, will then copy and transform the data as required. The data may be used to augment or totally replace the data they hold, if any.
 
@@ -20,7 +20,7 @@ We (will) have automation that looks for data daily. It will look for data in Gi
 - Has a file called `.json-schema-identification.json` in the project's root
 - The JSON file validates successfully against the version of the self identification JSON Schema it declares
 
-While this tooling will initially only use GitHub, we will begin working on supporting other source hosts as soon as possible. We recognize that GitHub is not the only source code platform. If you'd like to help with this, please reach make yourself know in our Slack server.
+While this tooling will initially only use GitHub, we will begin working on supporting other source hosts as soon as possible. We recognize that GitHub is not the only source code platform. If you'd like to help with this, please reach make yourself know in our [Slack server](https://json-schema.org/slack).
 
 ## Why should I include this file in my tooling repository?
 
@@ -28,3 +28,38 @@ If you define this file in your tooling repository, you will:
 - Be able to update your listing on the JSON Schema website's tooling page
 - Have your tool listing show it's project status and be filterable based on the project status
 - Have your tool shown in the JSON Schema Landscape diagram (unless you opt out)
+
+## Tooling categories definitions
+
+The `toolingType` field defines the category or type of tool, which enables filtering by end users on the website. Here's an explanation of what each category means. If you're unsure what categories your tool fits into, please reach out to us on [Slack](https://json-schema.org/slack) or raise an Issue on GitHub.
+
+<details>
+<summary>View Category Definitions</summary>
+
+<table>
+<thead><tr><th>Value</th><th>Definition</th><tr></thead>
+<tr><td>"validator"</td><td>A library which itself directly validates JSON data using a JSON Schema, providing an assertion result.</td></tr>
+<tr><td>"hyper-schema"</td><td>A library which provides utility and processing in relation to JSON Hyper Schema.</td></tr>
+<tr><td>"benchmarks"</td><td>A tool which performs benchmarking of JSON Schema tooling.</td></tr>
+<tr><td>"LDO-utility"</td><td>A library which provides utility in relation to Link Description Objects found in JSON Hyper Schema.</td></tr>
+<tr><td>"code-to-schema"</td><td>A tool or library which enables the creation of a JSON Schema from existing <b>code</b>.</td></tr>
+<tr><td>"data-to-schema"</td><td>A tool or library which enables the creation of a JSON Schema from existing <b>data</b>.</td></tr>
+<tr><td>"model-to-schema"</td><td>A tool or library which enables the creation of a JSON Schema from existing <b>models</b>.</td></tr>
+<tr><td>"schema-to-types"</td><td>A tool or library which enables the creation of <b>types</b> from a JSON Schema.</td></tr>
+<tr><td>"schema-to-code"</td><td>A tool or library which enables the creation of <b>code</b> from a JSON Schema.</td></tr>
+<tr><td>"schema-to-web-UI"</td><td>A tool or library which enables the creation of <b>Web UI (such as forms)</b> from a JSON Schema.</td></tr>
+<tr><td>"schema-to-data"</td><td>A tool or library which enables the creation of <b>data</b> from a JSON Schema.</td></tr>
+<tr><td>"util-general-processing"</td><td>A library or tool which makes processing and using JSON Schema easier.</td></tr>
+<tr><td>"util-schema-to-schema"</td><td>A library or tool which enables or provides utilities to assist with Schema to Schema transformations.</td></tr>
+<tr><td>"util-draft-migration"</td><td>A library or tool which enables or provides utilities to assist with JSON Schema version/draft migration.</td></tr>
+<tr><td>"util-format-conversion"</td><td>A library or tool which enables or provides utilities to assist with converting from a format to or from JSON Schema.</td></tr>
+<tr><td>"util-testing"</td><td>A library or tool which enables or provides utilities to assist with utilizing JSON Schema with tests.</td></tr>
+<tr><td>"editor"</td><td>A tool which allows you to create and edit JSON documents with specific support for authoring and editing JSON Schema documents.</td></tr>
+<tr><td>"editor-plugins"</td><td>Plugins for editors which augment the use of JSON Schema within an editor.</td></tr>
+<tr><td>"schema-to-documentation"</td><td>A tool or library which enables the creation of <b>documentation</b> from a JSON Schema.</td></tr>
+<tr><td>"schema-repository"</td><td>A collection of Schemas. This may not be an example of best use, nor does it signal endorsement.</td></tr>
+<tr><td>"linter"</td><td>A tool or library which provides the ability for rule based validation of JSON Schemas.</td></tr>
+<tr><td>"linter-plugins"</td><td>Plugins for other linter based tooling which enables rule based validation of JSON Schemas.</td></tr>
+</table>
+
+</details>

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -55,11 +55,11 @@ If you define this file in your tooling repository, you will:
 
 ## What will happen with the data?
 
-Data that's collected when it meets the above stated criteria will be used to create a Pull Request into the ecosystem repo to add or update the information.
-
-The data for tools lives in a single file in this repository, and will be duplicated out to the website repository and the landscape repository when modified. (You can opt-out of appearing in the landscape diagram if you wish, by setting `landscape > optOut` to `true`. This will mean the tool will only appear on the website.)
+Data that's collected when it meets the above stated criteria copied into a file in the ecosystem repository. A Pull Request will then automatically be created to copy modifications into another file.
 
 The Pull Request will be reviewed by the JSON Schema team. If we need to ask for changes to your data file, we will do so by raising an Issue in the originating repository.
+
+The resulting final data for tools lives in a file in this repository, and will be duplicated out to the website repository and the landscape repository when modified. (You can opt-out of appearing in the landscape diagram if you wish, by setting `landscape > optOut` to `true`. This will mean the tool will only appear on the website.)
 
 When we receive and accept Maintainer-Provided data for a tool or library, we will remove the entry from the Community-Contributed Legacy data.
 

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -1,0 +1,28 @@
+# Self Identification of Open Source JSON Schema Tooling
+
+JSON Schema has a vast ecosystem. We have documented a fraction of the existing tools out there for JSON Schema.
+
+This project aims to enable tooling authors and maintainers to detail their tools existance and additional informaiton to be listed on the JSON Schema website and Landscape diagram.
+
+The approach is to define a data structure for a file which is located in their own repo, which will then be located and extracted into a single file within this repository. Other repositories such as the website and landscape repositories, will then copy and transform the data as required. The data may be used to augment or totally replace the data they hold, if any.
+
+## Just Open Source for now
+
+This project only aims to capture the open source tooling, and does not include detailing or tracking of tools which are not open source.
+
+There may be further projects which aim to collate and combine data collected from other locations (such as this project), and primary data (such as information deposited into the website or later this repository in relation to close source tools).
+
+## How do I self identify my tool?
+
+We (will) have automation that looks for data daily. It will look for data in GitHub repositories which meet the following conditions:
+
+- Repository has the Topic `json-schema` assigned
+- Has a file called `.json-schema-identification.json` in the project's root
+- The JSON file validates successfully against the version of the self identification JSON Schema it declares
+
+## Why should I include this file in my tooling repository?
+
+If you define this file in your tooling repository, you will:
+- Be able to update your listing on the JSON Schema website's tooling page
+- Have your tool listing show it's project status and be filterable based on the project status
+- Have your tool shown in the JSON Schema Landscape diagram (unless you opt out)

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -2,7 +2,7 @@
 
 JSON Schema has a vast ecosystem. We have documented a fraction of the existing tools out there for JSON Schema.
 
-This project aims to enable tooling authors and maintainers to detail their tools existence and additional information to be listed on the JSON Schema website and Landscape diagram.
+This project aims to enable tooling authors and maintainers to detail their tools' existence and additional information to be listed on the JSON Schema website and Landscape diagram.
 
 The approach is to define a data structure for a file which is located in their own repo, which will then be located and extracted into a single file within this repository. Other repositories such as the website and landscape repositories, will then copy and transform the data as required. The data may be used to augment or totally replace the data they hold, if any.
 

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -6,13 +6,37 @@ This project aims to enable tooling authors and maintainers to detail their tool
 
 The approach is to define a data structure for a file which is located in their own repo, which will then be located and extracted into a single file within this repository. Other repositories such as the website and landscape repositories, will then copy and transform the data as required. The data may be used to augment or totally replace the data they hold, if any.
 
+🚨 Note: This document details how everything SHOULD work when fully set up and running. The realization of this effort has not yet happened. This note will be removed once everything is working.
+
+## What data is here?
+
+In this repository in the `data` folder, there will be three files (sets of data) relating to tools and libraries which are in relation to this project.
+
+Community-Contributed Legacy data: The data provided by the community and maintainers which has been used for listing on the website.
+
+Maintainer-Provided data: The data provided by tooling and library maintainers through a file in their repositories, which is then copied into this repository.
+
+Ecosystem-Controlled Override data: The data used to override or correct data provided from maintainer repositories or legacy data.
+
+## What is the data used for?
+
+This data will be used for the listing of tools and libraries on the JSON Schema website, and for populating the JSON Schema landscape diagram (unless opted out).
+
+## How do I add to or modify the data?
+
+The Community-Contributed Legacy data is no longer accepting updates. No one should update this data.
+
+Any changes to the data requested by the maintainers or community should be done by detailing or updating self identifying data as explained later in this document. The Maintainer-Provided data in this repository should not be edited by anyone directly.
+
+The Ecosystem-Controlled Override data should hopefully not be used or modified very often. Such cases may be correcting data where the maintainer is no longer responding to requests to change the data or accept a Pull Request which would make the fix. This will only be edited by the JSON Schema team.
+
 ## Just Open Source for now
 
 This project only aims to capture the open source tooling, and does not include detailing or tracking of tools which are not open source.
 
 There may be further projects which aim to collate and combine data collected from other locations (such as this project), and primary data (such as information deposited into the website or later this repository in relation to close source tools).
 
-## How do I self identify my tool?
+## How do I self identify my tool or library?
 
 We (will) have automation that looks for data daily. It will look for data in GitHub repositories which meet the following conditions:
 
@@ -28,6 +52,16 @@ If you define this file in your tooling repository, you will:
 - Be able to update your listing on the JSON Schema website's tooling page
 - Have your tool listing show it's project status and be filterable based on the project status
 - Have your tool shown in the JSON Schema Landscape diagram (unless you opt out)
+
+## What will happen with the data?
+
+Data that's collected when it meets the above stated criteria will be used to create a Pull Request into the ecosystem repo to add or update the information.
+
+The data for tools lives in a single file in this repository, and will be duplicated out to the website repository and the landscape repository when modified. (You can opt-out of appearing in the landscape diagram if you wish, by setting `landscape > optOut` to `true`. This will mean the tool will only appear on the website.)
+
+The Pull Request will be reviewed by the JSON Schema team. If we need to ask for changes to your data file, we will do so by raising an Issue in the originating repository.
+
+When we receive and accept Maintainer-Provided data for a tool or library, we will remove the entry from the Community-Contributed Legacy data.
 
 ## Tooling categories definitions
 
@@ -63,3 +97,21 @@ The `toolingType` field defines the category or type of tool, which enables filt
 </table>
 
 </details>
+
+## My tool or library is already on the website or landscape diagram, but I haven't added the file. Where did that come from?
+
+Over the years many people have added to the list of "implementations" or tools on the JSON Schema website. We are using the data from the website repository as the basis for the initial data in this repository in relation to details of a tool or library.
+
+## The data shown on the site or the landscape diagram is different to the data I provided in the repository. What's happening?
+
+We reserve the right to override and/or augment any aspect of the provided data where we feel it is the right thing to do for whatever reason. We will do so by using another file in this repository which will contain only overriding data, which will take precedence.
+
+## I created the required file but it's not showing up! What's happening?
+
+We understand it may be frustrating, but we are here to help!
+
+First, check the data is valid according to the JSON Schema.
+
+Second, check the provided source URL matches the the repository location. If it doesn't, we may assume your repository is a fork which isn't intended to be an alternative to the forked project, to avoid duplicate entries.
+
+Otherwise (or if you're not sure how to resolve the problems above), please reach out to us on [Slack](https://json-schema.org/slack) or raise an Issue on GitHub. We would love to hear from you!

--- a/projects/tooling-self-identification/readme.md
+++ b/projects/tooling-self-identification/readme.md
@@ -20,6 +20,8 @@ We (will) have automation that looks for data daily. It will look for data in Gi
 - Has a file called `.json-schema-identification.json` in the project's root
 - The JSON file validates successfully against the version of the self identification JSON Schema it declares
 
+While this tooling will initially only use GitHub, we will begin working on supporting other source hosts as soon as possible. We recognize that GitHub is not the only source code platform. If you'd like to help with this, please reach make yourself know in our Slack server.
+
 ## Why should I include this file in my tooling repository?
 
 If you define this file in your tooling repository, you will:


### PR DESCRIPTION
Related to https://github.com/json-schema-org/community/issues/412 (but does not close).
(This PR probably needs a specific Issue. Sorry.)

This PR introduces a JSON Schema which details the data structure that tooling repositories will be asked to included to self identify themselves to the JSON Schema Ecosystem project.

When the JSON Schema Ecosystem project ingests the data, it will be the Single Source of Truth for that data (beyond the source repositories). The data will then be pulled to the website repository and the landscape repository.

At this stage I'm looking for feedback and comments on the schema. I'll update with an Issue and providing a readme for tooling implementers to help them understand the expectations and what will be done with the data and why.

Work to do based on feedback:

- [x] Describe all of the tooling catagories in the readme
- [x] Specify the process for pulling in data and that it triggers a PR rather than just being accepted, as any change should be manually reviewed by a member of the JSON Schema team
- [x] Pluralize consistently
- [x] Clarify purpose of `languages` field
- [x] Require full URL of depended on validators and detail that the validator should already be known to the ecosystem repo to be accepted
- [x] Correct use of `format` to `uri`
- [x] Add field to declare support for other defined dialects
- [x] Define ingested data as automated into one file, and curated data into another file with overrides as manual with PR (created automatically)