### PR TITLE
fix: auto add the data directory

### DIFF
--- a/projects/initial-data/dataRecorder.js
+++ b/projects/initial-data/dataRecorder.js
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 
 export class DataRecorder {
   constructor(fileName, columns = []) {
@@ -9,6 +10,8 @@ export class DataRecorder {
 
   #createFile() {
     if (!fs.existsSync(this.fileName)) {
+      const dir = path.dirname(this.fileName);
+      if (dir) fs.mkdirSync(dir, { recursive: true });
       const headerLine = `${this.columns.join(',')}\n`;
       fs.writeFileSync(this.fileName, headerLine, 'utf8');
     }


### PR DESCRIPTION
Fixes: #18 

Description
- Auto-create the `data/` output directory if it doesn't exist before writing the CSV file.  